### PR TITLE
Fixed issue with GetListViewCheckedItems()

### DIFF
--- a/listView.go
+++ b/listView.go
@@ -1115,7 +1115,7 @@ func GetListViewCheckedItems(view View, subviewID ...string) []int {
 					return checkedItems
 
 				case SingleCheckbox:
-					if len(checkedItems) > 1 {
+					if len(checkedItems) > 0 {
 						return []int{checkedItems[0]}
 					}
 				}


### PR DESCRIPTION
 API(doesn't return checked item if list is in SingleCheckbox mode and exactly one item has been selected)